### PR TITLE
メニューに[点検予定未作成の設備一覧]を追加する #8（飛ばし直しです。）

### DIFF
--- a/app/views/equipment/noInspectionList.html.erb
+++ b/app/views/equipment/noInspectionList.html.erb
@@ -1,3 +1,4 @@
+<% breadcrumb :equipment_no_inspection_index %>
 <h1><%= t('views.equipment.no_inspection_index') %></h1>
 
 <%= form_tag action='create_inspections' do %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -34,6 +34,7 @@
     <div class="collapse navbar-collapse" id="navlink">
       <ul class="nav navbar-nav">
        <li class="navbar-brand-small"> <%= breadcrumbs  %> </li>
+
         <li class="dropdown">
           <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false"><%= t('views.menu.show.daily_work') %><span class="caret"></span></a>
           <ul class="dropdown-menu" role="menu">
@@ -41,6 +42,12 @@
           </ul>
         </li>
 
+        <li class="dropdown">
+          <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false"><%= t('views.menu.show.management_work') %><span class="caret"></span></a>
+          <ul class="dropdown-menu" role="menu">
+            <li><%= link_to t('views.equipment.no_inspection_index'), noinspection_list_path %></li>
+          </ul>
+        </li>
 
         <li class="dropdown">
           <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false"><%= t('views.menu.show.maintanance_master') %><span class="caret"></span></a>

--- a/app/views/menu/show.html.erb
+++ b/app/views/menu/show.html.erb
@@ -11,6 +11,14 @@
 
 
 <hr>
+<h2><%= t('views.menu.show.management_work') %></h2>
+
+<p>
+  <%= link_to t('views.equipment.no_inspection_index'), noinspection_list_path %>
+</p>
+
+
+<hr>
 <h2><%= t('views.menu.show.maintanance_master') %></h2>
 
 <p>

--- a/config/breadcrumbs/equipments.rb
+++ b/config/breadcrumbs/equipments.rb
@@ -17,3 +17,8 @@ crumb :equipment_show do
   link t('views.equipment.show'), nil
   parent :maint
 end
+
+crumb :equipment_no_inspection_index do
+  link t('views.equipment.no_inspection_index'), nil
+  parent :maint
+end

--- a/config/locales/views.ja.yml
+++ b/config/locales/views.ja.yml
@@ -4,6 +4,7 @@ ja:
       show:
         title: メニュー
         daily_work: 日常業務
+        management_work: 管理業務
         maintanance_master: マスター登録
         maintanance_sys: システム管理者用
     link_to:
@@ -24,7 +25,7 @@ ja:
       new: 設備の登録
       edit: 設備の更新
       show: 設備の確認
-      no_inspection_index: 点検予定未作成の設備一覧
+      no_inspection_index: 設備一覧(点検予定なし)
     place:
       index: 場所の一覧
       new: 場所の登録


### PR DESCRIPTION
点検予定未作成の設備一覧はあまりにも長いので、せめて…という感じで
「設備一覧(点検予定なし)」に変更してます。
※もうちょっといい名前思いついたらそのとき考えます…

あと、やったことは以下の通り。
・メニュー画面にリンク追加
・メニューバーにリンク追加
・パンくずリストにも追加
