### PR TITLE
点検開始画面の記録者に点検担当者をデフォルトで入れる

### DIFF
--- a/app/controllers/inspections_controller.rb
+++ b/app/controllers/inspections_controller.rb
@@ -20,6 +20,7 @@ class InspectionsController < ApplicationController
   def do_inspection
     @kirokus = @inspection.kiroku.all
     @kiroku = @inspection.kiroku.build
+    @kiroku.worker_id = @inspection.worker_id
     @check =  @kiroku.build_check
     @measurement = @kiroku.build_measurement
     @note = @kiroku.build_note


### PR DESCRIPTION
#59 です。

コントローラーで新規のkirokuを作った時に親のinspectionのworker_id突っ込んでます
